### PR TITLE
Replace Config object with Base._get method

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -256,7 +256,7 @@ def test_short_stack():
     d = da.from_array(x, chunks=(1,))
     s = da.stack([d])
     assert s.shape == (1, 1)
-    assert get(s.dask, s._keys())[0][0].shape == (1, 1)
+    assert Array._get(s.dask, s._keys())[0][0].shape == (1, 1)
 
 
 def test_stack_scalars():

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -30,7 +30,7 @@ from ..core import istask, get_dependencies, reverse_dict
 from ..optimize import fuse, cull, inline
 from ..compatibility import (apply, BytesIO, unicode, urlopen, urlparse, quote,
         unquote, StringIO)
-from ..base import Base, Config
+from ..base import Base
 
 names = ('bag-%d' % i for i in itertools.count(1))
 tokens = ('-%d' % i for i in itertools.count(1))
@@ -184,12 +184,11 @@ def finalize(bag, results):
     return results
 
 
-config = Config(optimize, mpget, finalize)
-get = config.get
-
-
 class Item(Base):
-    _config = config
+    _optimize = staticmethod(optimize)
+    _default_get = staticmethod(mpget)
+    _finalize = staticmethod(finalize)
+
     def __init__(self, dsk, key):
         self.dask = dsk
         self.key = key
@@ -235,7 +234,10 @@ class Bag(Base):
     >>> int(b.fold(lambda x, y: x + y))  # doctest: +SKIP
     30
     """
-    _config = config
+    _optimize = staticmethod(optimize)
+    _default_get = staticmethod(mpget)
+    _finalize = staticmethod(finalize)
+
     def __init__(self, dsk, name, npartitions):
         self.dask = dsk
         self.name = name

--- a/dask/dataframe/io.py
+++ b/dask/dataframe/io.py
@@ -15,7 +15,7 @@ from ..base import compute
 from .. import array as da
 
 from . import core
-from .core import DataFrame, Series, concat, categorize_block, tokens, get
+from .core import DataFrame, Series, concat, categorize_block, tokens
 from .shuffle import set_partition
 
 
@@ -541,7 +541,7 @@ def to_hdf(df, path_or_buf, key, mode='a', append=False, complevel=0,
                             'complevel': complevel, 'complib': complib,
                             'fletcher32': fletcher32}))
 
-    get(merge(df.dask, dsk), (name, i), **kwargs)
+    DataFrame._get(merge(df.dask, dsk), (name, i), **kwargs)
 
 
 dont_use_fixed_error_message = """
@@ -595,7 +595,7 @@ def to_castra(df, fn=None, categories=None):
         dsk[(name, i)] = (_link, (name, i - 1),
                           (Castra.extend, (name, -1), (df._name, i)))
 
-    c, _ = get(merge(dsk, df.dask), [(name, -1), list(dsk.keys())])
+    c, _ = DataFrame._get(merge(dsk, df.dask), [(name, -1), list(dsk.keys())])
     return c
 
 
@@ -618,4 +618,4 @@ def to_csv(df, filename, **kwargs):
                              (tuple, [(df._name, i), filename]),
                              kwargs2))
 
-    get(merge(dsk, df.dask), (name, df.npartitions - 1), get=myget)
+    DataFrame._get(merge(dsk, df.dask), (name, df.npartitions - 1), get=myget)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 
 from ..optimize import cull
-from .core import DataFrame, Series, get, _Frame, tokens
+from .core import DataFrame, Series, _Frame, tokens
 from .utils import (strip_categories, shard_df_on_index, _categorize,
                     get_categories)
 
@@ -94,7 +94,7 @@ def set_partition(df, index, divisions, compute=False, **kwargs):
         dsk = merge(df.dask, dsk1, dsk2, dsk3)
         if isinstance(index, _Frame):
             dsk.update(index.dask)
-        p, barrier_token, categories = get(dsk, [p, barrier_token, catname], **kwargs)
+        p, barrier_token, categories = df._get(dsk, [p, barrier_token, catname], **kwargs)
         dsk4 = {catname2: categories}
     else:
         dsk4 = {}

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -8,7 +8,7 @@ import dask
 from dask.async import get_sync
 from dask.utils import raises
 import dask.dataframe as dd
-from dask.dataframe.core import (get, concat, repartition_divisions, _loc,
+from dask.dataframe.core import (concat, repartition_divisions, _loc,
         _coerce_loc_index)
 
 
@@ -401,7 +401,7 @@ def test_categorize():
 
     assert list(cfull.a.astype('O')) == list(full.a)
 
-    assert (get(c.dask, c._keys()[:1])[0].dtypes == cfull.dtypes).all()
+    assert (d._get(c.dask, c._keys()[:1])[0].dtypes == cfull.dtypes).all()
 
     assert (d.categorize().compute().dtypes == 'category').all()
 
@@ -613,7 +613,7 @@ def test_repartition():
     b = a.repartition(divisions=[10, 20, 50, 60])
     assert b.divisions == (10, 20, 50, 60)
     assert eq(a, b)
-    assert eq(get(b.dask, (b._name, 0)), df.iloc[:1])
+    assert eq(a._get(b.dask, (b._name, 0)), df.iloc[:1])
 
 
 def test_repartition_divisions():

--- a/dask/dataframe/tests/test_io.py
+++ b/dask/dataframe/tests/test_io.py
@@ -167,7 +167,7 @@ def test_read_csv_categorize_and_index():
         result = f.compute(get=get_sync)
         assert result.index.name == 'amount'
 
-        blocks = dd.core.get(f.dask, f._keys(), get=get_sync)
+        blocks = dd.DataFrame._get(f.dask, f._keys(), get=get_sync)
         for i, block in enumerate(blocks):
             if i < len(f.divisions):
                 assert (block.index <= f.divisions[i + 1]).all()


### PR DESCRIPTION
This flattens out the `_config` attribute to three `staticfunction`s (as I think was done before).  The `Config.get` method has been moved to `Base._get`.

I also started using `Array._get` in place of `da.core.get` though this is somewhat orthogonal and could be changed back easily.

This essentially drops the logic of the `Config` class into `Base`.

Thoughts on this?  I think that this satisfies the objectives laid out in https://github.com/ContinuumIO/dask/pull/504/files#r36147158
